### PR TITLE
Fix spectral Schema

### DIFF
--- a/.spectral.json
+++ b/.spectral.json
@@ -1,5 +1,4 @@
 {
-  "formats": [],
   "extends": [
     "spectral:oas"
   ],


### PR DESCRIPTION
Fix spectral Schema. Formats was moved elsewhere and is no longer expected on the top level.